### PR TITLE
Update express from 2.5 to 4.3.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 var express = require('express');
-var app     = express.createServer();
-var port    = process.env.PORT || 3000;
+var app = express();
+var port = process.env.PORT || 3000;
 
-app.get('/', function(request, response) {
-  response.send('Hello Engine Yard Cloud!');
+app.get('/', function (req, res) {
+  res.send('Hello Engine Yard Cloud!')
 });
 
 app.listen(port);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-simple-example",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "dependencies": {
-    "express": "2.5.0"
+    "express": "4.13.4"
   }
 }


### PR DESCRIPTION
## Description

Update express from 2.5 to 4.3.
## Testing

Created a new app and environment:

```
Application Language: Node.js

Node Environment: production
Application Server Stack: Nginx
Stack: stable-v4 2.0
Database Stack: No DB

Custom Cluster Configuration: 1 app instance
```

After booting up the environment, `node -v` shows 0.10.38. After an Apply, `node -v` shows 4.2.1. The updated application works on both versions (restarted the Node app via god restart). The changing Node version is another issue we need to fix soon, but that's outside the scope of this pull request.
